### PR TITLE
modification du parser de fichier Fantoir pour TOPO

### DIFF
--- a/lib/commune.js
+++ b/lib/commune.js
@@ -5,24 +5,26 @@ function parseCommune(record, options = {}) {
     throw new Error('parseDate is required')
   }
 
+  // Les communes ont un code typo = 13
   const dates = extractDates(record, options.parseDate)
+  const codeTypo = record.slice(16, 18)
+  if (codeTypo === '13') {
+    const result = {
+      type: 'commune',
+      codeDepartement: parseCodeDepartement(record),
+      codeCommune: record.slice(7, 12),
+      nomCommune: record.slice(18, 88).trim(),
+      ...dates
+    }
 
-  const result = {
-    type: 'commune',
-    codeDepartement: parseCodeDepartement(record),
-    codeCommune: record.slice(0, 2) + record.slice(3, 6),
-    cleRivoli: record.charAt(10),
-    nomCommune: record.slice(11, 41).trim(),
-    ...dates
+    result.id = `${result.codeCommune}`
+
+    if (options.computeCompleteIds) {
+      result.hid = `commune:${result.codeCommune}@${dates.dateAjout}`
+    }
+
+    return result
   }
-
-  result.id = `${result.codeCommune}`
-
-  if (options.computeCompleteIds) {
-    result.hid = `commune:${result.codeCommune}@${dates.dateAjout}`
-  }
-
-  return result
 }
 
 module.exports = {parseCommune}

--- a/lib/dates.js
+++ b/lib/dates.js
@@ -1,12 +1,12 @@
 function parseDateNative(str) {
-  if (str.length !== 7) {
-    throw new Error('parseDate is expecting a string with size 7. Given: ' + str.length)
+  if (str.length !== 8) {
+    throw new Error('parseDate is expecting a string with size 8. Given: ' + str.length)
   }
 
   const year = str.slice(0, 4)
-  const dayOfYear = str.slice(4, 7)
-  const date = new Date(year) // UTC
-  date.setDate(dayOfYear)
+  const month = str.slice(4, 6) - 1
+  const day = str.slice(6, 8)
+  const date = new Date(year, month, day, 1, 0, 0) // UTC
   return date
 }
 
@@ -16,8 +16,8 @@ function parseDateISO(str) {
 }
 
 function parseDateInteger(str) {
-  if (str.length !== 7) {
-    throw new Error('parseDate is expecting a string with size 7. Given: ' + str.length)
+  if (str.length !== 8) {
+    throw new Error('parseDate is expecting a string with size 8. Given: ' + str.length)
   }
 
   return Number.parseInt(str, 10)

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -15,10 +15,8 @@ const FIELDS = [
   'codeDepartement',
   'codeCommune',
   'codeRivoli',
-  'cleRivoli',
   'libelleVoie',
   'voiePrivee',
-  'codeMajic',
   'codeNatureVoie',
   'natureVoie',
   'dateAnnulation',
@@ -32,41 +30,15 @@ function flatten(record) {
   return Buffer.from(record).toString()
 }
 
-function isAlphaNumeric(char) {
-  return (char >= '0' && char <= '9') || (char >= 'A' && char <= 'Z')
-}
-
 function parseRecord(record, {accept, parseDate, computeCompleteIds}) {
-  // EOF
-  if (record.slice(0, 6) === '999999') {
-    if (accept.includes('eof')) {
-      return {type: 'eof'}
-    }
-
-    return
-  }
-
-  // Initial record
-  if (!isAlphaNumeric(record.charAt(0))) {
-    return
-  }
-
-  // Direction record
-  if (!isAlphaNumeric(record.charAt(3))) {
-    return
-  }
-
+  const codeTypo = record.slice(16, 18)
   // Commune record
-  if (!isAlphaNumeric(record.charAt(6))) {
-    if (accept.includes('commune')) {
-      return parseCommune(flatten(record), {parseDate, computeCompleteIds})
-    }
-
-    return
+  if (codeTypo === '13' && accept.includes('commune')) {
+    return parseCommune(flatten(record), {parseDate, computeCompleteIds})
   }
 
   // Voie
-  if (accept.includes('voie')) {
+  if (codeTypo === '14' && accept.includes('voie')) {
     return parseVoie(flatten(record), {parseDate, computeCompleteIds})
   }
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,14 +1,14 @@
 function extractDates(record, parseDate) {
   const result = {}
 
-  const dateAjout = record.slice(81, 88)
+  const dateAjout = record.slice(102, 110)
   if (dateAjout === '0000000') {
     throw new Error('Données inattendues : date d’ajout manquante')
   }
 
   result.dateAjout = parseDate(dateAjout)
 
-  const annulation = record.charAt(73)
+  const annulation = record.charAt(93)
   if (annulation === 'Q') {
     result.typeAnnulation = 'avec transfert'
   }
@@ -17,7 +17,7 @@ function extractDates(record, parseDate) {
     result.typeAnnulation = 'sans transfert'
   }
 
-  const dateAnnulation = record.slice(74, 81)
+  const dateAnnulation = record.slice(94, 101)
   if (dateAnnulation !== '0000000') {
     result.dateAnnulation = parseDate(dateAnnulation)
   }
@@ -26,11 +26,11 @@ function extractDates(record, parseDate) {
 }
 
 function parseCodeDepartement(str) {
-  if (str.slice(0, 2) === '97') {
-    return str.slice(0, 3)
+  if (str.slice(7, 9) === '97') {
+    return str.slice(7, 10)
   }
 
-  return str.slice(0, 2)
+  return str.slice(7, 9)
 }
 
 module.exports = {parseCodeDepartement, extractDates}

--- a/lib/voie.js
+++ b/lib/voie.js
@@ -14,49 +14,50 @@ function parseVoie(record, options = {}) {
     throw new Error('parseDate is required')
   }
 
-  const codeTypeVoie = record.charAt(108)
+  const codeTypeVoie = record.charAt(110)
   const typeVoie = TYPE_VOIE[codeTypeVoie]
   const dates = extractDates(record, options.parseDate)
-
-  const result = {
-    type: 'voie',
-    codeTypeVoie,
-    typeVoie,
-    codeDepartement: parseCodeDepartement(record),
-    codeCommune: record.slice(0, 2) + record.slice(3, 6),
-    codeRivoli: record.slice(6, 10),
-    cleRivoli: record.charAt(10),
-    libelleVoie: record.slice(15, 41).trim(),
-    voiePrivee: record.slice(48, 49) === '1',
-    codeMajic: record.slice(103, 108),
-    motDirecteur: record.slice(112, 120).trim(),
-    ...dates
-  }
-
-  result.id = `${result.codeCommune}-${result.codeRivoli}`
-
-  if (options.computeCompleteIds) {
-    result.hid = `voie:${result.id}@${dates.dateAjout}`
-  }
-
-  const codeNatureVoie = record.slice(11, 15).trim()
-  if (codeNatureVoie.length > 0) {
-    result.codeNatureVoie = codeNatureVoie
-    if (codeNatureVoie in naturesVoies) {
-      const natureVoie = naturesVoies[codeNatureVoie]
-      result.natureVoie = Array.isArray(natureVoie) ? natureVoie[0] : natureVoie
-    } else {
-      result.natureVoie = codeNatureVoie
+  const codeTypo = record.slice(16, 18)
+  if (codeTypo === '14') {
+    const result = {
+      type: 'voie',
+      codeTypeVoie,
+      typeVoie,
+      codeDepartement: parseCodeDepartement(record),
+      codeCommune: record.slice(7, 12),
+      codeRivoli: record.slice(12, 16),
+      libelleVoie: record.slice(22, 92).trim(),
+      voiePrivee: record.charAt(93) === '1',
+      motDirecteur: record.slice(111, 119).trim(),
+      ...dates
     }
+    result.id = `${result.codeCommune}-${result.codeRivoli}`
+
+    if (options.computeCompleteIds) {
+      result.hid = `voie:${result.id}@${dates.dateAjout}`
+    }
+
+    const codeNatureVoie = record.slice(18, 22).trim()
+
+    if (codeNatureVoie.length > 0) {
+      result.codeNatureVoie = codeNatureVoie
+      if (codeNatureVoie in naturesVoies) {
+        const natureVoie = naturesVoies[codeNatureVoie]
+        result.natureVoie = Array.isArray(natureVoie) ? natureVoie[0] : natureVoie
+      } else {
+        result.natureVoie = codeNatureVoie
+      }
+    }
+
+    result.libelleVoieComplet = buildLibelleVoieComplet(result.natureVoie, result.libelleVoie)
+
+    if (typeVoie === 'lieu-dit') {
+      // ?
+      result.lieuDitBati = record.charAt(110) === '1'
+    }
+
+    return result
   }
-
-  result.libelleVoieComplet = buildLibelleVoieComplet(result.natureVoie, result.libelleVoie)
-
-  if (typeVoie === 'lieu-dit') {
-    result.lieuDitBati = record.charAt(109) === '1'
-  }
-
-  return result
 }
 
 function buildLibelleVoieComplet(natureVoie, libelleVoie) {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "@etalab/fantoir-parser",
+  "name": "@ban-team/fantoir-parser",
   "version": "0.5.0",
-  "description": "Analyseur de fichiers FANTOIR",
+  "description": "Analyseur de fichiers TOPO-FANTOIR",
   "publishConfig": {
     "access": "public"
   },
   "main": "index.js",
-  "repository": "git@github.com:etalab/fantoir-parser.git",
+  "repository": "https://github.com/BaseAdresseNationale/fantoir-parser",
   "author": "Jérôme Desboeufs <jerome.desboeufs@data.gouv.fr>",
   "license": "MIT",
   "private": false,

--- a/test/dates.js
+++ b/test/dates.js
@@ -2,5 +2,5 @@ const test = require('ava')
 const {parseDateISO} = require('../lib/dates')
 
 test('parseDateISO', t => {
-  t.is(parseDateISO('2018070'), '2018-03-11')
+  t.is(parseDateISO('20180311'), '2018-03-11')
 })

--- a/test/stream.js
+++ b/test/stream.js
@@ -4,10 +4,10 @@ const {parseStream} = require('../lib/stream')
 
 test('parse input stream', async t => {
   const input = intoStream([
-    '540084    YMONT-BONVILLERS                N  3      000108100000000000000 00000001987001',
-    '5400840020FALL DES ACACIAS                N  3  0          00000000000000 00000001987001               001151   ACACIAS'
+    '991000197101A01114RES AIR FRANCE DUGAZON                                                    0 00000000198701012DUGAZON 00000000',
+    '991000197101A01414LOT PETIT ACAJOU                                                          0 00000000199602272ACAJOU  20051220'
   ].join('\n'))
   const records = await parseStream(input)
-  t.is(records.length, 1)
-  t.is(records[0].id, '54084-0020')
+  t.is(records.length, 2)
+  t.is(records[0].id, '97101-A011')
 })

--- a/test/voie.js
+++ b/test/voie.js
@@ -3,24 +3,22 @@ const {parseVoie} = require('../lib/voie')
 const {parseDateISO} = require('../lib/dates')
 
 test('parse voie', t => {
-  const rawRecord = '5400840020FALL DES ACACIAS                N  3  0          00000000000000 00000001987001               001151   ACACIAS'
+  const rawRecord = '991000197101A01114RES AIR FRANCE DUGAZON                                                    0 00000000198701012DUGAZON 00000000'
   t.deepEqual(parseVoie(rawRecord, {parseDate: parseDateISO, computeCompleteIds: true}), {
     type: 'voie',
     dateAjout: '1987-01-01',
-    cleRivoli: 'F',
-    codeCommune: '54084',
-    codeDepartement: '54',
-    codeMajic: '00115',
-    codeNatureVoie: 'ALL',
-    codeRivoli: '0020',
-    codeTypeVoie: '1',
-    hid: 'voie:54084-0020@1987-01-01',
-    id: '54084-0020',
-    libelleVoie: 'DES ACACIAS',
-    libelleVoieComplet: 'ALLEE DES ACACIAS',
-    motDirecteur: 'ACACIAS',
-    natureVoie: 'ALLEE',
-    typeVoie: 'voie',
-    voiePrivee: false
+    codeCommune: '97101',
+    codeDepartement: '971',
+    codeRivoli: 'A011',
+    codeNatureVoie: 'RES',
+    codeTypeVoie: '2',
+    hid: 'voie:97101-A011@1987-01-01',
+    id: '97101-A011',
+    libelleVoie: 'AIR FRANCE DUGAZON',
+    libelleVoieComplet: 'RESIDENCE AIR FRANCE DUGAZON',
+    motDirecteur: 'DUGAZON',
+    natureVoie: 'RESIDENCE',
+    typeVoie: 'ensemble immobilier',
+    voiePrivee: false,
   })
 })


### PR DESCRIPTION
Modifications impactantes : 
-> La date passe sur 8 caractères au lieu de 7
-> disparition des codes MAJIC et clé RIVOLI du fichier TOPO 
**Attention impact pour l'explorateur de FANTOIR on n'a plus a afficher la clef rivoli**
**Attention impact pour fantoir on n'a plus la clef rivoli**
-> ajout d'un code sur 2 caractères "Type de Topo" permettant de savoir si la ligne correspond à une commune (=13) ou une voie (=14)
-> les champs sont décalés en général

_Résultats_ : 
commune : 
**avant** :  https://[plateforme.adresse.data.gouv.fr/api-fantoir/departements/971/communes](https://plateforme.adresse.data.gouv.fr/api-fantoir/departements/971/communes)
{"type":"commune","codeDepartement":"971","codeCommune":"97101","cleRivoli":"V","nomCommune":"LES ABYMES","dateAjout":"1987-01-01","id":"97101"}
**après** : http://[localhost:5000/departements/971/communes](http://localhost:5000/departements/971/communes)
{"type":"commune","codeDepartement":"971","codeCommune":"97101","nomCommune":"LES ABYMES","dateAjout":"1987-01-01","id":"97101"}

voies : 

**avant** : https://[plateforme.adresse.data.gouv.fr/api-fantoir/communes/97101/voies](https://plateforme.adresse.data.gouv.fr/api-fantoir/communes/97101/voies)
{"type":"voie","codeTypeVoie":"2","typeVoie":"ensemble immobilier","codeRivoli":"A011","cleRivoli":"D","libelleVoie":"AIR FRANCE DUGAZON","voiePrivee":false,"codeMajic":"00002","motDirecteur":"DUGAZON","dateAjout":"1987-01-01","id":"97101-A011","codeNatureVoie":"RES","natureVoie":"RESIDENCE","libelleVoieComplet":"RESIDENCE AIR FRANCE DUGAZON"}
**après** : http://[localhost](http://localhost:5000/communes/97101/voies):5000/communes/97101/voies
{"type":"voie","codeTypeVoie":"2","typeVoie":"ensemble immobilier","codeRivoli":"A011","libelleVoie":"AIR FRANCE DUGAZON","voiePrivee":false,"motDirecteur":"DUGAZON","dateAjout":"1987-01-01","id":"97101-A011","codeNatureVoie":"RES","natureVoie":"RESIDENCE","libelleVoieComplet":"RESIDENCE AIR FRANCE DUGAZON"}

Testé en faisant un yarn link du repo pour api-fantoir. yarn link "@etalab/fantoir-parser"
Puis : npm instal --global serve
Puis : serve sauv -l 8000
le fichier est servi on peut le capter en remplaçant dans load-data.js ligne 68 
got.stream('http://localhost:8000/extraitTopo.gz')
fichier à mettre dans un dossier sauv à la racine du repo api-fantoir
[extraitTopo.gz](https://github.com/BaseAdresseNationale/fantoir-parser/files/12016007/extraitTopo.gz)


fix #14 


